### PR TITLE
Removed space typo that apparently exists

### DIFF
--- a/data/namelist.js
+++ b/data/namelist.js
@@ -5,7 +5,7 @@ exports.namelist = {
 		"fuzz",
 		"-kitty",
 		"-kat",
-		"bun ",
+		"bun",
 		"poof",
 		"heallo",
 		"deallo",


### PR DESCRIPTION
Literally just a space in namelist.js that was bugging people. They yelled at me to fix it. This is it being fixed. 

Sorry for the literal one character pull request ._.

As always, harass me if you need me to handle anything with this. I'll jump on it right away 👍 