### PR TITLE
Commands: fix the mail command

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -433,7 +433,7 @@ exports.commands = {
 	mail: 'message',
 	msg: 'message',
 	message: function(arg, by, room) {
-		if (!by.paw && !by.canUse('message', getRoom("art"))) return by.say('``\mail`` is only available to users ' + Data.settings.commands.message.art || config.defaultrank + ' and above and those with "roompaw".');
+		if (!by.paw && !by.canUse('message', getRoom("art"))) return by.say('``\mail`` is only available to users ' + (Data.settings.commands.message.art || config.defaultrank) + ' and above and those with "roompaw".');
 		var parts = arg.split(', ');
 		var target = toId(parts[0]);
 		if (Users[target]) target = getUser(target).id;


### PR DESCRIPTION
The mail command would break if the user couldn't use it within the Art room because the logical OR statement wasn't wrapped in parentheses; as a result, the bot would always default to trying to evaluate `Data.settings.commands.message.art` because a non-empty string is a truthy value. It would break simply because `Data.settings.commands.message.art` might not exist yet.